### PR TITLE
Fix TypeError

### DIFF
--- a/iker.py
+++ b/iker.py
@@ -533,7 +533,7 @@ def fingerprintVID (args, vpns, handshake=None):
 			
 			if b"VID=" in line and b"(" in line and b")" in line and b"draft-ietf" not in line and b"IKE Fragmentation" not in line and b"Dead Peer Detection" not in line and b"XAUTH" not in line and b"RFC 3947" not in line and b"Heartbeat Notify" not in line:
 				
-				vid = line[line.index('(')+1:line.index(')')]
+				vid = line[line.index(b"(")+1:line.index(b")")]
 		
 		enc = False
 		for pair in vpns[ip]["vid"]:


### PR DESCRIPTION
Python 3.11.2
When starting, the following error appears
```
[*] Checking for IKE version 2 support...
Traceback (most recent call last):
  File "/mnt/e/Downloads/iker.py", line 1102, in <module>
    main()
  File "/mnt/e/Downloads/iker.py", line 1078, in main
    fingerprintVID (args, vpns)
  File "/mnt/e/Downloads/iker.py", line 536, in fingerprintVID
    vid = line[line.index('(')+1:line.index(')')]
               ^^^^^^^^^^^^^^^
TypeError: argument should be integer or bytes-like object, not 'str'
```

This changes fix it